### PR TITLE
Repopulate records table with empty QUERY_ROOT after caches are cleared

### DIFF
--- a/AWSAppSyncClient/AWSAppSyncClientConfiguration.swift
+++ b/AWSAppSyncClient/AWSAppSyncClientConfiguration.swift
@@ -587,13 +587,7 @@ public class AWSAppSyncClientConfiguration {
         if let databaseURL = databaseURL, let cache = try? AWSSQLiteNormalizedCache(fileURL: databaseURL) {
             store = ApolloStore(cache: cache)
         } else {
-            // Prepopulate the InMemoryNormalizedCache record set with an empty QUERY_ROOT, to allow optimistic
-            // updates against empty caches to succeed. Otherwise, such an operation will fail with a "missingValue"
-            // error (#92)
-            let emptyQueryRootRecord = Record(key: AWSAppSyncClient.EmptyQuery.rootCacheKey, [:])
-            let records = RecordSet(records: [emptyQueryRootRecord])
-            let inMemoryCache = InMemoryNormalizedCache(records: records)
-            store = ApolloStore(cache: inMemoryCache)
+            store = ApolloStore(cache: InMemoryNormalizedCache())
         }
         return store
     }

--- a/AWSAppSyncClient/Apollo/Sources/Apollo/InMemoryNormalizedCache.swift
+++ b/AWSAppSyncClient/Apollo/Sources/Apollo/InMemoryNormalizedCache.swift
@@ -2,7 +2,16 @@ public final class InMemoryNormalizedCache: NormalizedCache {
   private var records: RecordSet
 
   public init(records: RecordSet = RecordSet()) {
-    self.records = records
+    if records.isEmpty {
+      // Prepopulate the InMemoryNormalizedCache record set with an empty QUERY_ROOT, to allow optimistic
+      // updates against empty caches to succeed. Otherwise, such an operation will fail with a "missingValue"
+      // error (#92)
+      let emptyQueryRootRecord = Record(key: AWSAppSyncClient.EmptyQuery.rootCacheKey, [:])
+      self.records = RecordSet(records: [emptyQueryRootRecord])
+    }
+    else {
+      self.records = records
+    }
   }
 
   public func loadRecords(forKeys keys: [CacheKey]) -> Promise<[Record?]> {
@@ -16,6 +25,13 @@ public final class InMemoryNormalizedCache: NormalizedCache {
 
   public func clear() -> Promise<Void> {
     records.clear()
+
+    // Prepopulate the InMemoryNormalizedCache record set with an empty QUERY_ROOT, to allow optimistic
+    // updates against empty caches to succeed. Otherwise, such an operation will fail with a "missingValue"
+    // error (#92)
+    let emptyQueryRootRecord = Record(key: AWSAppSyncClient.EmptyQuery.rootCacheKey, [:])
+    self.records = RecordSet(records: [emptyQueryRootRecord])
+
     return Promise(fulfilled: ())
   }
 }

--- a/AWSAppSyncClient/Internal/AWSSQLiteNormalizedCache.swift
+++ b/AWSAppSyncClient/Internal/AWSSQLiteNormalizedCache.swift
@@ -54,6 +54,13 @@ final class AWSSQLiteNormalizedCache: NormalizedCache {
     func clear() -> Promise<Void> {
         return Promise {
             try db.run(self.records.delete())
+            // Prepopulate the cache with an empty QUERY_ROOT, to allow optimistic updates of query results that have
+            // not yet been retrieved from the service. This works around Apollo's behavior of throwing an error if
+            // readObject find no records. (#92)
+            try db.run(self.records.insert(
+                key <- AWSSQLiteNormalizedCache.queryRootKey,
+                record <- "{}"
+            ))
         }
     }
 

--- a/AWSAppSyncUnitTests/MutationOptimisticUpdateTests.swift
+++ b/AWSAppSyncUnitTests/MutationOptimisticUpdateTests.swift
@@ -37,11 +37,19 @@ class MutationOptimisticUpdateTests: XCTestCase {
     }
 
     func testMutation_WithOptimisticUpdate_UpdatesEmptyPersistentCache() throws {
-        try doMutationWithOptimisticUpdate(usingBackingDatabase: true)
+        try doMutationWithOptimisticUpdate(usingBackingDatabase: true, afterClearingCaches: false)
     }
 
     func testMutation_WithOptimisticUpdate_UpdatesEmptyInMemoryCache() throws {
-        try doMutationWithOptimisticUpdate(usingBackingDatabase: false)
+        try doMutationWithOptimisticUpdate(usingBackingDatabase: false, afterClearingCaches: false)
+    }
+
+    func testMutation_WithOptimisticUpdate_UpdatesEmptyPersistentCacheAfterClearingCaches() throws {
+        try doMutationWithOptimisticUpdate(usingBackingDatabase: true, afterClearingCaches: true)
+    }
+
+    func testMutation_WithOptimisticUpdate_UpdatesEmptyInMemoryCacheAfterClearingCaches() throws {
+        try doMutationWithOptimisticUpdate(usingBackingDatabase: false, afterClearingCaches: true)
     }
 
     func testMutation_WithoutOptimisticUpdate_DoesNotUpdateEmptyCache() throws {
@@ -203,7 +211,8 @@ class MutationOptimisticUpdateTests: XCTestCase {
 
     // MARK - Utility methods
 
-    func doMutationWithOptimisticUpdate(usingBackingDatabase: Bool) throws {
+    func doMutationWithOptimisticUpdate(usingBackingDatabase: Bool,
+                                        afterClearingCaches: Bool) throws {
         let addPost = DefaultTestPostData.defaultCreatePostWithoutFileUsingParametersMutation
 
         // We will set up a response block that never actually invokes the completion handler. This allows us to
@@ -222,6 +231,10 @@ class MutationOptimisticUpdateTests: XCTestCase {
             : nil
 
         let appSyncClient = try UnitTestHelpers.makeAppSyncClient(using: mockHTTPTransport, cacheConfiguration: resolvedCacheConfiguration)
+
+        if afterClearingCaches {
+            try appSyncClient.clearCaches()
+        }
 
         let newPost = ListPostsQuery.Data.ListPost(
             id: "TEMPORARY-\(UUID().uuidString)",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
